### PR TITLE
Allow library type to be dictated by BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core)
 include_directories("src" "miniz")
 
 # sources
-add_library(qmicroz SHARED
+add_library(qmicroz
   src/qmicroz.h
   src/qmicroz.cpp
   src/tools.h


### PR DESCRIPTION
The explicit use of "SHARED" forces the generation of a shared library binary (preventing compiling the project as a static lib). Removing the parameter allows the type of the library to be dictated by the value of `BUILD_SHARED_LIBS` (on for SHARED, off for STATIC), which is commonly used in consumer projects.

As noted in the CMake documentation for `BUILD_SHARED_LIBS`, it's common to add it as a cache variable, to make it more obvious it's intended to be set by consumers for those who aren't familiar, though there can be caveats if the project is not the top-level project. Therefore, I usually wrap the creation for the CACHE variable of `BUILD_SHARED_LIBS` in a conditional check of `PROJECT_IS_TOP_LEVEL`, though that wasn't added till CMake 3.21 and I didn't want to bump the minimum version just for this.