### PR TITLE
Fix mismatched allocation/deallocation in extractData

### DIFF
--- a/src/qmicroz.cpp
+++ b/src/qmicroz.cpp
@@ -611,7 +611,7 @@ QByteArray QMicroz::extractData(int index) const
     QByteArray extrCopy(extrRef.constData(), extrRef.size());
 
     // Clear extracted from the heap
-    delete extrRef.constData();
+    free((void*)extrRef.constData());
 
     return extrCopy;
 }


### PR DESCRIPTION
The underlying library, miniz, is a C library that uses malloc to allocate memory in mz_zip_reader_extract_to_heap. The previous implementation attempted to release this memory using the C++ delete operator.
According to the C++ standard, allocating with malloc and freeing with delete is Undefined Behavior. While it may work on some allocators, it causes corruption on others.

I did not encounter any undefined behaviour with this myself, but I came across it while checking the previous PR with Valgrind.

The Valgrind output before the fix is as follows:
`valgrind --tool=memcheck --leak-check=full --log-file=valgrind_log.txt ./test_qmicroz`

``` cpp
...
==356436== Mismatched free() / delete / delete []
==356436==    at 0x489F8DD: operator delete(void*, unsigned long) (vg_replace_malloc.c:1181)
==356436==    by 0x401AC54: QMicroz::extractData(int) const (in /home/gaunah/workspace/qmicroz/build_before_fix/test_qmicroz)
==356436==    by 0x400AF34: test_qmicroz::test_setZipWriting() (in /home/gaunah/workspace/qmicroz/build_before_fix/test_qmicroz)
==356436==    by 0x400D260: test_qmicroz::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) (in /home/gaunah/workspace/qmicroz/build_before_fix/test_qmicroz)
...
```